### PR TITLE
Add custom chrome path

### DIFF
--- a/src/find-chrome.ts
+++ b/src/find-chrome.ts
@@ -29,13 +29,11 @@ const paths: string[] =
         '/snap/bin/chromium',
       ]
 
-export function findChrome(chromePath?: string | string[]): string {
-  const allPaths = paths;
+export function findChrome(chromePath?: string): string {
   if (chromePath) {
-    if (!Array.isArray(chromePath)) allPaths.push(chromePath);
-    else allPaths.push(...chromePath);
+    paths.push(chromePath);
   }
-  for (const p of allPaths) {
+  for (const p of paths) {
     if (fs.existsSync(p)) {
       return p
     }

--- a/src/find-chrome.ts
+++ b/src/find-chrome.ts
@@ -29,8 +29,13 @@ const paths: string[] =
         '/snap/bin/chromium',
       ]
 
-export function findChrome(): string {
-  for (const p of paths) {
+export function findChrome(chromePath?: string | string[]): string {
+  const allPaths = paths;
+  if (chromePath) {
+    if (!Array.isArray(chromePath)) allPaths.push(chromePath);
+    else allPaths.push(...chromePath);
+  }
+  for (const p of allPaths) {
     if (fs.existsSync(p)) {
       return p
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ export type TakiOptions = {
   onBeforeClosingPage?: (page: Page) => void | Promise<void>
   minify?: boolean
   resourceFilter?: (ctx: ResourceFilterCtx) => boolean
-  blockCrossOrigin?: boolean
+  blockCrossOrigin?: boolean,
+  chromePath?: string | string[]
 }
 
 async function getHTML(browser: Browser, options: TakiOptions) {
@@ -112,7 +113,7 @@ export async function request(options: TakiOptions[]): Promise<string[]>
 export async function request(options: TakiOptions | TakiOptions[]) {
   if (!browser) {
     browser = await pptr.launch({
-      executablePath: findChrome(),
+      executablePath: findChrome(options.chromePath),
       // headless: false,
     })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,8 @@ export type TakiOptions = {
   onBeforeClosingPage?: (page: Page) => void | Promise<void>
   minify?: boolean
   resourceFilter?: (ctx: ResourceFilterCtx) => boolean
-  blockCrossOrigin?: boolean,
-  chromePath?: string | string[]
+  blockCrossOrigin?: boolean
+  chromePath?: string
 }
 
 async function getHTML(browser: Browser, options: TakiOptions) {
@@ -112,8 +112,17 @@ export async function request(options: TakiOptions[]): Promise<string[]>
 
 export async function request(options: TakiOptions | TakiOptions[]) {
   if (!browser) {
+    let chromePath;
+    if (Array.isArray(options)) {
+      // get first occurrences of chromePath
+      const optChromePath = options.find(opt => opt.chromePath);
+      if (optChromePath) chromePath = optChromePath.chromePath;
+    } else {
+      chromePath = options.chromePath;
+    }
+
     browser = await pptr.launch({
-      executablePath: findChrome(options.chromePath),
+      executablePath: findChrome(chromePath),
       // headless: false,
     })
   }


### PR DESCRIPTION
This PR adds the possibility to the user to set his own chrome path.

Use case:
- pre-render a website using [presite](https://github.com/egoist/taki) on Netlify using [netlify-plugin-chromium](https://github.com/soofka/netlify-plugin-chromium)